### PR TITLE
query length max changed 200 to avoid github API error: `The search is longer than 256 characters.`

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -169,7 +169,7 @@ module Git
           shas.each do |sha|
             # Longer than 256 characters are not supported in the query.
             # ref. https://docs.github.com/en/rest/reference/search#limitations-on-query-length
-            if query.length + 1 + sha.length >= 256
+            if query.length + 1 + sha.length >= 200
               pr_nums.concat(search_issue_numbers(query))
               query = query_base
             end


### PR DESCRIPTION
I set query length to 200.
The number of API calls will increase, but we can avoid errors.